### PR TITLE
Added optional request body parameter 'idempotenceKey'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## Unreleased
+## UNRELEASED
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Optional request body parameter `idempotenceKey` for `::userReportMake` in `ClientInterface` and `Client`
+
 ## v3.4.0
 
 ### Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -268,7 +268,8 @@ class Client implements ClientInterface, WithSettingsInterface, WithEventsHandle
                                    ?bool $is_force = false,
                                    ?string $on_update = null,
                                    ?string $on_complete = null,
-                                   ?array $data = null): UserReportMakeResponse
+                                   ?array $data = null,
+                                   ?string $idempotence_key = null): UserReportMakeResponse
     {
         $request_options = [];
 
@@ -289,6 +290,10 @@ class Client implements ClientInterface, WithSettingsInterface, WithEventsHandle
             'query'     => $value,
             'options'   => (object) \array_replace($request_options, $options ?? []),
         ];
+
+        if (\is_string($idempotence_key)) {
+            $request_body['idempotenceKey'] = $idempotence_key;
+        }
 
         if (\is_array($data)) {
             $request_body['data'] = (object) $data;

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -155,10 +155,11 @@ interface ClientInterface
      * @param string|null       $on_update       Call (using `post` method) when report content updated
      * @param string|null       $on_complete     Call (using `post` method) when report generation completed
      * @param array<mixed>|null $data            Additional request data
+     * @param string|null       $idempotence_key Idempotence key which the server uses to recognize subsequent retries
+     *                                           of the same request.
      *
      * @throws BadRequestException
      * @throws BadResponseException
-     *
      * @return UserReportMakeResponse
      */
     public function userReportMake(string $report_type_uid,
@@ -168,7 +169,8 @@ interface ClientInterface
                                    ?bool $is_force = false,
                                    ?string $on_update = null,
                                    ?string $on_complete = null,
-                                   ?array $data = null): UserReportMakeResponse;
+                                   ?array $data = null,
+                                   ?string $idempotence_key = null): UserReportMakeResponse;
 
     /**
      * Refresh existing report.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -156,7 +156,7 @@ interface ClientInterface
      * @param string|null       $on_complete     Call (using `post` method) when report generation completed
      * @param array<mixed>|null $data            Additional request data
      * @param string|null       $idempotence_key Idempotence key which the server uses to recognize subsequent retries
-     *                                           of the same request.
+     *                                           of the same request
      *
      * @throws BadRequestException
      * @throws BadResponseException

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -160,6 +160,7 @@ interface ClientInterface
      *
      * @throws BadRequestException
      * @throws BadResponseException
+     *
      * @return UserReportMakeResponse
      */
     public function userReportMake(string $report_type_uid,


### PR DESCRIPTION
## Description

- Added optional request body parameter `idempotenceKey` for `::userReportMake` in `ClientInterface` and `Client`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
