### PR TITLE
Return `self` instead of `static` in some factory methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Method `ClientInterface::userReports` now takes optional object `UserReportsParams` as parameter
 - Method `ClientInterface::userReport` now takes object `UserReportParams` as parameter
 - Method `ClientInterface::userReportRefresh` now takes object `UserReportRefreshParams` as parameter
-- Stricter PHPStan checks (without `ignoreErrors`)
+- Faсtory methods now returns `self` instead of `static` in classes:
+  - `Avtocod\B2BApi\Exceptions\*`
+  - `Avtocod\B2BApi\Responses\Entities\*`
+  - `Avtocod\B2BApi\Responses\*Response`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Method `ClientInterface::userReports` now takes optional object `UserReportsParams` as parameter
 - Method `ClientInterface::userReport` now takes object `UserReportParams` as parameter
 - Method `ClientInterface::userReportRefresh` now takes object `UserReportRefreshParams` as parameter
-- Replace `new static` with `new self`
+- Stricter PHPStan checks (without `ignoreErrors`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Method `ClientInterface::userReportMake` now takes object `ReportMakeParams` as parameter
+- Replace `new static` with `new self`
 
 ### Fixed
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,10 +2,3 @@ parameters:
   level: 'max'
   paths:
     - src
-  ignoreErrors:
-    - # Replacing with `return new self` or classes finalization requires major version upping. Make it on next major release
-      message: '#Unsafe usage of new static\(\)#'
-      paths:
-        - src/Responses/*Response.php
-        - src/Responses/Entities/*.php
-        - src/Exceptions/*Exception.php

--- a/src/Exceptions/BadResponseException.php
+++ b/src/Exceptions/BadResponseException.php
@@ -44,7 +44,7 @@ class BadResponseException extends RuntimeException implements B2BApiExceptionIn
                                      ?string $message = null,
                                      ?Throwable $prev = null): self
     {
-        return new static($http_response, $message ?? 'Server sent wrong json', 0, $prev);
+        return new self($http_response, $message ?? 'Server sent wrong json', 0, $prev);
     }
 
     /**

--- a/src/Exceptions/TokenParserException.php
+++ b/src/Exceptions/TokenParserException.php
@@ -18,6 +18,6 @@ class TokenParserException extends RuntimeException implements B2BApiExceptionIn
      */
     public static function cannotParseToken(?string $message = null, int $code = 0, ?Throwable $prev = null): self
     {
-        return new static($message ?? 'Cannot parse token', $code, $prev);
+        return new self($message ?? 'Cannot parse token', $code, $prev);
     }
 }

--- a/src/Responses/DevPingResponse.php
+++ b/src/Responses/DevPingResponse.php
@@ -75,7 +75,7 @@ class DevPingResponse implements ResponseInterface
             throw BadResponseException::wrongJson($response, $e->getMessage(), $e);
         }
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['value'],
             $as_array['in'],

--- a/src/Responses/DevTokenResponse.php
+++ b/src/Responses/DevTokenResponse.php
@@ -137,7 +137,7 @@ class DevTokenResponse implements ResponseInterface
             throw BadResponseException::wrongJson($response, $e->getMessage(), $e);
         }
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['user'],
             $as_array['pass'],

--- a/src/Responses/Entities/Balance.php
+++ b/src/Responses/Entities/Balance.php
@@ -88,13 +88,11 @@ class Balance implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, mixed> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['report_type_uid'],
             $data['balance_type'],
             $data['quote_init'],

--- a/src/Responses/Entities/CanCreateSelfFromArrayInterface.php
+++ b/src/Responses/Entities/CanCreateSelfFromArrayInterface.php
@@ -7,9 +7,9 @@ interface CanCreateSelfFromArrayInterface
     /**
      * Create self using array of data.
      *
-     * @param array<mixed> $data
+     * @param array<string, mixed> $data
      *
-     * @return self|$this
+     * @return self
      */
     public static function fromArray(array $data);
 }

--- a/src/Responses/Entities/CleanOptions.php
+++ b/src/Responses/Entities/CleanOptions.php
@@ -36,13 +36,11 @@ class CleanOptions implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, int|null> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['Process_Response'] ?? null,
             $data['Process_Request'] ?? null,
             $data['ReportLog'] ?? null

--- a/src/Responses/Entities/Domain.php
+++ b/src/Responses/Entities/Domain.php
@@ -129,13 +129,11 @@ class Domain implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, mixed> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['uid'],
             $data['comment'],
             $data['name'],

--- a/src/Responses/Entities/Report.php
+++ b/src/Responses/Entities/Report.php
@@ -185,13 +185,11 @@ class Report implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, mixed> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['uid'],
             $data['comment'],
             $data['name'],

--- a/src/Responses/Entities/ReportMade.php
+++ b/src/Responses/Entities/ReportMade.php
@@ -46,13 +46,11 @@ class ReportMade implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, string|bool|null> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['uid'],
             $data['isnew'],
             $data['process_request_uid'] ?? null,

--- a/src/Responses/Entities/ReportQuery.php
+++ b/src/Responses/Entities/ReportQuery.php
@@ -36,13 +36,11 @@ class ReportQuery implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, string|array<mixed>|null> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['type'] ?? null,
             $data['body'] ?? null,
             $data['data'] ?? null

--- a/src/Responses/Entities/ReportSourceState.php
+++ b/src/Responses/Entities/ReportSourceState.php
@@ -51,13 +51,11 @@ class ReportSourceState implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, string|array<mixed>|null> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['_id'] ?? $data['id'] ?? $data['name'],
             $data['state'],
             $data['data'] ?? null

--- a/src/Responses/Entities/ReportState.php
+++ b/src/Responses/Entities/ReportState.php
@@ -22,13 +22,11 @@ class ReportState implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, array<string, mixed>> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             \array_map(static function (array $report_data): ReportSourceState {
                 return ReportSourceState::fromArray($report_data);
             }, $data['sources'])

--- a/src/Responses/Entities/ReportType.php
+++ b/src/Responses/Entities/ReportType.php
@@ -249,13 +249,11 @@ class ReportType implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, mixed> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['uid'],
             $data['comment'],
             $data['name'],

--- a/src/Responses/Entities/ReportTypeContent.php
+++ b/src/Responses/Entities/ReportTypeContent.php
@@ -29,13 +29,11 @@ class ReportTypeContent implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, array<string>> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['sources'],
             $data['fields']
         );

--- a/src/Responses/Entities/User.php
+++ b/src/Responses/Entities/User.php
@@ -192,13 +192,11 @@ class User implements CanCreateSelfFromArrayInterface
     }
 
     /**
-     * @param array<string, mixed> $data
-     *
-     * @return self
+     * @inheritDoc
      */
     public static function fromArray(array $data): self
     {
-        return new static(
+        return new self(
             $data['uid'],
             $data['comment'],
             $data['contacts'],

--- a/src/Responses/UserBalanceResponse.php
+++ b/src/Responses/UserBalanceResponse.php
@@ -88,7 +88,7 @@ class UserBalanceResponse implements ResponseInterface, Countable, IteratorAggre
             return Balance::fromArray($balance_data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],

--- a/src/Responses/UserReportMakeResponse.php
+++ b/src/Responses/UserReportMakeResponse.php
@@ -88,7 +88,7 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
             return ReportMade::fromArray($data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],

--- a/src/Responses/UserReportRefreshResponse.php
+++ b/src/Responses/UserReportRefreshResponse.php
@@ -88,7 +88,7 @@ class UserReportRefreshResponse implements ResponseInterface, Countable, Iterato
             return ReportMade::fromArray($data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],

--- a/src/Responses/UserReportResponse.php
+++ b/src/Responses/UserReportResponse.php
@@ -88,7 +88,7 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
             return Report::fromArray($data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],

--- a/src/Responses/UserReportTypesResponse.php
+++ b/src/Responses/UserReportTypesResponse.php
@@ -100,7 +100,7 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
             return ReportType::fromArray($report_type_data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],

--- a/src/Responses/UserReportsResponse.php
+++ b/src/Responses/UserReportsResponse.php
@@ -100,7 +100,7 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
             return Report::fromArray($report_data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],

--- a/src/Responses/UserResponse.php
+++ b/src/Responses/UserResponse.php
@@ -88,7 +88,7 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
             return User::fromArray($user_data);
         }, $as_array['data']);
 
-        return new static(
+        return new self(
             $raw_response,
             $as_array['state'],
             $as_array['size'],


### PR DESCRIPTION
## Description

### Changed

Faсtory methods now returns `self` instead of `static` in classes:
- `Avtocod\B2BApi\Exceptions\*`
- `Avtocod\B2BApi\Responses\Entities\*`
- `Avtocod\B2BApi\Responses\*Response`

Fixes #12 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
