### PR TITLE
Date/time objects in service responses & entities not immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
   - `Avtocod\B2BApi\Exceptions\*`
   - `Avtocod\B2BApi\Responses\Entities\*`
   - `Avtocod\B2BApi\Responses\*Response`
-- Date/time objects in service responses not immutable (`DateTimeImmutable` instead `DateTime`)
+- Date/time objects in service responses & entities not immutable (`DateTimeImmutable` instead `DateTime`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
   - `Avtocod\B2BApi\Exceptions\*`
   - `Avtocod\B2BApi\Responses\Entities\*`
   - `Avtocod\B2BApi\Responses\*Response`
+- Date/time objects in service responses not immutable (`DateTimeImmutable` instead `DateTime`)
 
 ### Fixed
 

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Avtocod\B2BApi;
 
 use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use InvalidArgumentException;
 
 /**
@@ -35,13 +37,40 @@ class DateTimeFactory extends DateTime
     }
 
     /**
+     * Create DateTime object from passed time string.
+     *
+     * @param string $time E.g.: '2017-01-05T16:45:23.000Z', '2017-01-05T16:45:23.000000Z',
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return DateTimeImmutable
+     */
+    public static function createImmutableFromIso8601Zulu(string $time): DateTimeImmutable
+    {
+        // @todo We can create base private function like a
+        //      function  createFrom***(string $time, string $class_name)
+        //      {
+        //           $result = $class_name::createFromFormat('Y-m-d\\TH:i:s.u\\Z', $time);
+        //      }
+        $result = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:s.u\\Z', $time);
+
+        if (! $result instanceof DateTimeImmutable) {
+            throw new InvalidArgumentException(
+                "Wrong time [$time] passed (" . \implode(',', DateTimeImmutable::getLastErrors()['errors'] ?? []) . ')'
+            );
+        }
+
+        return $result;
+    }
+
+    /**
      * Convert DateTime object into string, using ISO8601 (zulu) format.
      *
-     * @param DateTime $date_time
+     * @param DateTimeInterface $date_time
      *
      * @return string E.g.: '2017-01-05T16:45:23.000Z'
      */
-    public static function toIso8601Zulu(DateTime $date_time): string
+    public static function toIso8601Zulu(DateTimeInterface $date_time): string
     {
         return $date_time->format('Y-m-d\\TH:i:s.v\\Z');
     }

--- a/src/DateTimeFactory.php
+++ b/src/DateTimeFactory.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Avtocod\B2BApi;
 
 use DateTime;
-use DateTimeImmutable;
 use DateTimeInterface;
 use InvalidArgumentException;
 
@@ -30,33 +29,6 @@ class DateTimeFactory extends DateTime
         if (! $result instanceof DateTime) {
             throw new InvalidArgumentException(
                 "Wrong time [$time] passed (" . \implode(',', DateTime::getLastErrors()['errors'] ?? []) . ')'
-            );
-        }
-
-        return $result;
-    }
-
-    /**
-     * Create DateTime object from passed time string.
-     *
-     * @param string $time E.g.: '2017-01-05T16:45:23.000Z', '2017-01-05T16:45:23.000000Z',
-     *
-     * @throws InvalidArgumentException
-     *
-     * @return DateTimeImmutable
-     */
-    public static function createImmutableFromIso8601Zulu(string $time): DateTimeImmutable
-    {
-        // @todo We can create base private function like a
-        //      function  createFrom***(string $time, string $class_name)
-        //      {
-        //           $result = $class_name::createFromFormat('Y-m-d\\TH:i:s.u\\Z', $time);
-        //      }
-        $result = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:s.u\\Z', $time);
-
-        if (! $result instanceof DateTimeImmutable) {
-            throw new InvalidArgumentException(
-                "Wrong time [$time] passed (" . \implode(',', DateTimeImmutable::getLastErrors()['errors'] ?? []) . ')'
             );
         }
 

--- a/src/Responses/DevTokenResponse.php
+++ b/src/Responses/DevTokenResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Exceptions\BadResponseException;
@@ -34,7 +34,7 @@ class DevTokenResponse implements ResponseInterface
     protected $password_hash;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $date;
 
@@ -80,7 +80,7 @@ class DevTokenResponse implements ResponseInterface
      * @param string   $user
      * @param string   $password
      * @param string   $password_hash
-     * @param DateTime $date
+     * @param DateTimeImmutable $date
      * @param int      $stamp
      * @param int      $age
      * @param string   $salt
@@ -93,7 +93,7 @@ class DevTokenResponse implements ResponseInterface
                                  string $user,
                                  string $password,
                                  string $password_hash,
-                                 DateTime $date,
+                                 DateTimeImmutable $date,
                                  int $stamp,
                                  int $age,
                                  string $salt,
@@ -142,7 +142,7 @@ class DevTokenResponse implements ResponseInterface
             $as_array['user'],
             $as_array['pass'],
             $as_array['pass_hash'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['date']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['date']),
             $as_array['stamp'],
             $as_array['age'],
             $as_array['salt'],
@@ -178,9 +178,9 @@ class DevTokenResponse implements ResponseInterface
     }
 
     /**
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getDate(): DateTime
+    public function getDate(): DateTimeImmutable
     {
         return $this->date;
     }

--- a/src/Responses/DevTokenResponse.php
+++ b/src/Responses/DevTokenResponse.php
@@ -142,7 +142,7 @@ class DevTokenResponse implements ResponseInterface
             $as_array['user'],
             $as_array['pass'],
             $as_array['pass_hash'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['date']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['date'])),
             $as_array['stamp'],
             $as_array['age'],
             $as_array['salt'],

--- a/src/Responses/DevTokenResponse.php
+++ b/src/Responses/DevTokenResponse.php
@@ -76,18 +76,18 @@ class DevTokenResponse implements ResponseInterface
     /**
      * Create a new response instance.
      *
-     * @param string   $raw_response
-     * @param string   $user
-     * @param string   $password
-     * @param string   $password_hash
+     * @param string            $raw_response
+     * @param string            $user
+     * @param string            $password
+     * @param string            $password_hash
      * @param DateTimeImmutable $date
-     * @param int      $stamp
-     * @param int      $age
-     * @param string   $salt
-     * @param string   $salted_pass_hash
-     * @param string   $raw_token
-     * @param string   $token
-     * @param string   $header
+     * @param int               $stamp
+     * @param int               $age
+     * @param string            $salt
+     * @param string            $salted_pass_hash
+     * @param string            $raw_token
+     * @param string            $token
+     * @param string            $header
      */
     private function __construct(string $raw_response,
                                  string $user,

--- a/src/Responses/Entities/Balance.php
+++ b/src/Responses/Entities/Balance.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 
 class Balance implements CanCreateSelfFromArrayInterface
@@ -50,12 +50,12 @@ class Balance implements CanCreateSelfFromArrayInterface
     protected $quote_use;
 
     /**
-     * @var DateTime|null
+     * @var DateTimeImmutable|null
      */
     protected $created_at;
 
     /**
-     * @var DateTime|null
+     * @var DateTimeImmutable|null
      */
     protected $updated_at;
 
@@ -67,16 +67,16 @@ class Balance implements CanCreateSelfFromArrayInterface
      * @param int           $quote_init      Initial quota value
      * @param int           $quote_up        Added quota value
      * @param int           $quote_use       Used quota value
-     * @param DateTime|null $created_at      Balance entry created at
-     * @param DateTime|null $updated_at      Last changes was made at
+     * @param DateTimeImmutable|null $created_at      Balance entry created at
+     * @param DateTimeImmutable|null $updated_at      Last changes was made at
      */
     public function __construct(string $report_type_uid,
                                 string $balance_type,
                                 int $quote_init,
                                 int $quote_up,
                                 int $quote_use,
-                                ?DateTime $created_at,
-                                ?DateTime $updated_at)
+                                ?DateTimeImmutable $created_at,
+                                ?DateTimeImmutable $updated_at)
     {
         $this->report_type_uid = $report_type_uid;
         $this->balance_type    = $balance_type;
@@ -99,10 +99,10 @@ class Balance implements CanCreateSelfFromArrayInterface
             $data['quote_up'],
             $data['quote_use'],
             isset($data['created_at'])
-                ? DateTimeFactory::createFromIso8601Zulu($data['created_at'])
+                ? DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['created_at']))
                 : null,
             isset($data['updated_at'])
-                ? DateTimeFactory::createFromIso8601Zulu($data['updated_at'])
+                ? DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['updated_at']))
                 : null
         );
     }
@@ -160,9 +160,9 @@ class Balance implements CanCreateSelfFromArrayInterface
     /**
      * Get created at date/time.
      *
-     * @return DateTime|null
+     * @return DateTimeImmutable|null
      */
-    public function getCreatedAt(): ?DateTime
+    public function getCreatedAt(): ?DateTimeImmutable
     {
         return $this->created_at;
     }
@@ -170,9 +170,9 @@ class Balance implements CanCreateSelfFromArrayInterface
     /**
      * Get last changes date/time.
      *
-     * @return DateTime|null
+     * @return DateTimeImmutable|null
      */
-    public function getUpdatedAt(): ?DateTime
+    public function getUpdatedAt(): ?DateTimeImmutable
     {
         return $this->updated_at;
     }

--- a/src/Responses/Entities/Balance.php
+++ b/src/Responses/Entities/Balance.php
@@ -62,11 +62,11 @@ class Balance implements CanCreateSelfFromArrayInterface
     /**
      * Create a new balance instance.
      *
-     * @param string        $report_type_uid Report type unique identifier
-     * @param string        $balance_type    Balance entry type (e.g.: `DAY`, `MONTH`, `TOTAL`)
-     * @param int           $quote_init      Initial quota value
-     * @param int           $quote_up        Added quota value
-     * @param int           $quote_use       Used quota value
+     * @param string                 $report_type_uid Report type unique identifier
+     * @param string                 $balance_type    Balance entry type (e.g.: `DAY`, `MONTH`, `TOTAL`)
+     * @param int                    $quote_init      Initial quota value
+     * @param int                    $quote_up        Added quota value
+     * @param int                    $quote_use       Used quota value
      * @param DateTimeImmutable|null $created_at      Balance entry created at
      * @param DateTimeImmutable|null $updated_at      Last changes was made at
      */

--- a/src/Responses/Entities/Domain.php
+++ b/src/Responses/Entities/Domain.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 
 class Domain implements CanCreateSelfFromArrayInterface
@@ -40,7 +40,7 @@ class Domain implements CanCreateSelfFromArrayInterface
     protected $tags;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $created_at;
 
@@ -50,7 +50,7 @@ class Domain implements CanCreateSelfFromArrayInterface
     protected $created_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $updated_at;
 
@@ -60,12 +60,12 @@ class Domain implements CanCreateSelfFromArrayInterface
     protected $updated_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_from;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_to;
 
@@ -88,12 +88,12 @@ class Domain implements CanCreateSelfFromArrayInterface
      * @param string             $state       Domain state (e.g.: `DRAFT`, `ACTIVE`, `BANNED`)
      * @param array<string>|null $roles       Domain roles (optional)
      * @param array<string>      $tags        Additional domain tags
-     * @param DateTime           $created_at  Domain created at
+     * @param DateTimeImmutable           $created_at  Domain created at
      * @param string             $created_by  Domain creator
-     * @param DateTime           $updated_at  Last changes was made at
+     * @param DateTimeImmutable           $updated_at  Last changes was made at
      * @param string             $updated_by  Last changes was made by
-     * @param DateTime           $active_from Active from
-     * @param DateTime           $active_to   Active to
+     * @param DateTimeImmutable           $active_from Active from
+     * @param DateTimeImmutable           $active_to   Active to
      * @param int|null           $id          Internal database identifier (optional, only for administrators)
      * @param bool|null          $deleted     Is deleted flag (optional, only for administrators)
      */
@@ -103,12 +103,12 @@ class Domain implements CanCreateSelfFromArrayInterface
                                 string $state,
                                 ?array $roles,
                                 array $tags,
-                                DateTime $created_at,
+                                DateTimeImmutable $created_at,
                                 string $created_by,
-                                DateTime $updated_at,
+                                DateTimeImmutable $updated_at,
                                 string $updated_by,
-                                DateTime $active_from,
-                                DateTime $active_to,
+                                DateTimeImmutable $active_from,
+                                DateTimeImmutable $active_to,
                                 ?int $id,
                                 ?bool $deleted)
     {
@@ -142,12 +142,12 @@ class Domain implements CanCreateSelfFromArrayInterface
                 ? \array_filter(\explode(',', $data['roles']))
                 : null,
             \array_filter(\explode(',', $data['tags'])),
-            DateTimeFactory::createFromIso8601Zulu($data['created_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['created_at'])),
             $data['created_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['updated_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['updated_at'])),
             $data['updated_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['active_from']),
-            DateTimeFactory::createFromIso8601Zulu($data['active_to']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_from'])),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_to'])),
             $data['id'] ?? null,
             $data['deleted'] ?? null
         );
@@ -216,9 +216,9 @@ class Domain implements CanCreateSelfFromArrayInterface
     /**
      * Get created at date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->created_at;
     }
@@ -236,9 +236,9 @@ class Domain implements CanCreateSelfFromArrayInterface
     /**
      * Get last changes date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updated_at;
     }
@@ -256,9 +256,9 @@ class Domain implements CanCreateSelfFromArrayInterface
     /**
      * Get active from date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveFrom(): DateTime
+    public function getActiveFrom(): DateTimeImmutable
     {
         return $this->active_from;
     }
@@ -266,9 +266,9 @@ class Domain implements CanCreateSelfFromArrayInterface
     /**
      * Get active to date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveTo(): DateTime
+    public function getActiveTo(): DateTimeImmutable
     {
         return $this->active_to;
     }

--- a/src/Responses/Entities/Domain.php
+++ b/src/Responses/Entities/Domain.php
@@ -88,12 +88,12 @@ class Domain implements CanCreateSelfFromArrayInterface
      * @param string             $state       Domain state (e.g.: `DRAFT`, `ACTIVE`, `BANNED`)
      * @param array<string>|null $roles       Domain roles (optional)
      * @param array<string>      $tags        Additional domain tags
-     * @param DateTimeImmutable           $created_at  Domain created at
+     * @param DateTimeImmutable  $created_at  Domain created at
      * @param string             $created_by  Domain creator
-     * @param DateTimeImmutable           $updated_at  Last changes was made at
+     * @param DateTimeImmutable  $updated_at  Last changes was made at
      * @param string             $updated_by  Last changes was made by
-     * @param DateTimeImmutable           $active_from Active from
-     * @param DateTimeImmutable           $active_to   Active to
+     * @param DateTimeImmutable  $active_from Active from
+     * @param DateTimeImmutable  $active_to   Active to
      * @param int|null           $id          Internal database identifier (optional, only for administrators)
      * @param bool|null          $deleted     Is deleted flag (optional, only for administrators)
      */

--- a/src/Responses/Entities/Group.php
+++ b/src/Responses/Entities/Group.php
@@ -87,12 +87,12 @@ class Group
      * @param array<int, User>|null $users       Group users list (optional)
      * @param array<string>|null    $roles       Group roles list (optional)
      * @param array<string>         $tags        Additional group tags
-     * @param DateTimeImmutable              $created_at  Group created at
+     * @param DateTimeImmutable     $created_at  Group created at
      * @param string                $created_by  Group creator
-     * @param DateTimeImmutable              $updated_at  Last changes was made at
+     * @param DateTimeImmutable     $updated_at  Last changes was made at
      * @param string                $updated_by  Last changes was made by
-     * @param DateTimeImmutable              $active_from Active from
-     * @param DateTimeImmutable              $active_to   Active to
+     * @param DateTimeImmutable     $active_from Active from
+     * @param DateTimeImmutable     $active_to   Active to
      * @param int|null              $id          Internal database identifier (optional, only for administrators)
      * @param bool|null             $deleted     Is deleted flag (optional, only for administrators)
      */

--- a/src/Responses/Entities/Group.php
+++ b/src/Responses/Entities/Group.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 
 class Group
 {
@@ -39,7 +39,7 @@ class Group
     protected $tags;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $created_at;
 
@@ -49,7 +49,7 @@ class Group
     protected $created_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $updated_at;
 
@@ -59,12 +59,12 @@ class Group
     protected $updated_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_from;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_to;
 
@@ -87,12 +87,12 @@ class Group
      * @param array<int, User>|null $users       Group users list (optional)
      * @param array<string>|null    $roles       Group roles list (optional)
      * @param array<string>         $tags        Additional group tags
-     * @param DateTime              $created_at  Group created at
+     * @param DateTimeImmutable              $created_at  Group created at
      * @param string                $created_by  Group creator
-     * @param DateTime              $updated_at  Last changes was made at
+     * @param DateTimeImmutable              $updated_at  Last changes was made at
      * @param string                $updated_by  Last changes was made by
-     * @param DateTime              $active_from Active from
-     * @param DateTime              $active_to   Active to
+     * @param DateTimeImmutable              $active_from Active from
+     * @param DateTimeImmutable              $active_to   Active to
      * @param int|null              $id          Internal database identifier (optional, only for administrators)
      * @param bool|null             $deleted     Is deleted flag (optional, only for administrators)
      */
@@ -102,12 +102,12 @@ class Group
                                 ?array $users,
                                 ?array $roles,
                                 array $tags,
-                                DateTime $created_at,
+                                DateTimeImmutable $created_at,
                                 string $created_by,
-                                DateTime $updated_at,
+                                DateTimeImmutable $updated_at,
                                 string $updated_by,
-                                DateTime $active_from,
-                                DateTime $active_to,
+                                DateTimeImmutable $active_from,
+                                DateTimeImmutable $active_to,
                                 ?int $id,
                                 ?bool $deleted)
     {
@@ -190,9 +190,9 @@ class Group
     /**
      * Get created at date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->created_at;
     }
@@ -210,9 +210,9 @@ class Group
     /**
      * Get last changes date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updated_at;
     }
@@ -230,9 +230,9 @@ class Group
     /**
      * Get active from date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveFrom(): DateTime
+    public function getActiveFrom(): DateTimeImmutable
     {
         return $this->active_from;
     }
@@ -240,9 +240,9 @@ class Group
     /**
      * Get active to date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveTo(): DateTime
+    public function getActiveTo(): DateTimeImmutable
     {
         return $this->active_to;
     }

--- a/src/Responses/Entities/Report.php
+++ b/src/Responses/Entities/Report.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 
 class Report implements CanCreateSelfFromArrayInterface
@@ -55,7 +55,7 @@ class Report implements CanCreateSelfFromArrayInterface
     protected $tags;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $created_at;
 
@@ -65,7 +65,7 @@ class Report implements CanCreateSelfFromArrayInterface
     protected $created_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $updated_at;
 
@@ -75,12 +75,12 @@ class Report implements CanCreateSelfFromArrayInterface
     protected $updated_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_from;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_to;
 
@@ -126,12 +126,12 @@ class Report implements CanCreateSelfFromArrayInterface
      * @param string             $report_type_uid Report type unique ID
      * @param string             $domain_uid      Domain unique ID
      * @param array<string>      $tags            Tags list
-     * @param DateTime           $created_at      Created at
+     * @param DateTimeImmutable           $created_at      Created at
      * @param string             $created_by      Creator name
-     * @param DateTime           $updated_at      Last changes was made at
+     * @param DateTimeImmutable           $updated_at      Last changes was made at
      * @param string             $updated_by      Last changes was made by
-     * @param DateTime           $active_from     Active from
-     * @param DateTime           $active_to       Active to
+     * @param DateTimeImmutable           $active_from     Active from
+     * @param DateTimeImmutable           $active_to       Active to
      * @param int                $progress_ok     Successfully completed sources count
      * @param int                $progress_wait   Sources in a progress count
      * @param int                $progress_error  Errored sources count
@@ -148,12 +148,12 @@ class Report implements CanCreateSelfFromArrayInterface
                                 string $report_type_uid,
                                 string $domain_uid,
                                 array $tags,
-                                DateTime $created_at,
+                                DateTimeImmutable $created_at,
                                 string $created_by,
-                                DateTime $updated_at,
+                                DateTimeImmutable $updated_at,
                                 string $updated_by,
-                                DateTime $active_from,
-                                DateTime $active_to,
+                                DateTimeImmutable $active_from,
+                                DateTimeImmutable $active_to,
                                 int $progress_ok,
                                 int $progress_wait,
                                 int $progress_error,
@@ -201,12 +201,12 @@ class Report implements CanCreateSelfFromArrayInterface
             $data['report_type_uid'],
             $data['domain_uid'],
             \array_filter(\explode(',', $data['tags'])),
-            DateTimeFactory::createFromIso8601Zulu($data['created_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['created_at'])),
             $data['created_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['updated_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['updated_at'])),
             $data['updated_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['active_from']),
-            DateTimeFactory::createFromIso8601Zulu($data['active_to']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_from'])),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_to'])),
             $data['progress_ok'],
             $data['progress_wait'],
             $data['progress_error'],
@@ -309,9 +309,9 @@ class Report implements CanCreateSelfFromArrayInterface
     /**
      * Get created at date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->created_at;
     }
@@ -329,9 +329,9 @@ class Report implements CanCreateSelfFromArrayInterface
     /**
      * Get last changes date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updated_at;
     }
@@ -349,9 +349,9 @@ class Report implements CanCreateSelfFromArrayInterface
     /**
      * Get active from date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveFrom(): DateTime
+    public function getActiveFrom(): DateTimeImmutable
     {
         return $this->active_from;
     }
@@ -359,9 +359,9 @@ class Report implements CanCreateSelfFromArrayInterface
     /**
      * Get active to date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveTo(): DateTime
+    public function getActiveTo(): DateTimeImmutable
     {
         return $this->active_to;
     }

--- a/src/Responses/Entities/Report.php
+++ b/src/Responses/Entities/Report.php
@@ -126,12 +126,12 @@ class Report implements CanCreateSelfFromArrayInterface
      * @param string             $report_type_uid Report type unique ID
      * @param string             $domain_uid      Domain unique ID
      * @param array<string>      $tags            Tags list
-     * @param DateTimeImmutable           $created_at      Created at
+     * @param DateTimeImmutable  $created_at      Created at
      * @param string             $created_by      Creator name
-     * @param DateTimeImmutable           $updated_at      Last changes was made at
+     * @param DateTimeImmutable  $updated_at      Last changes was made at
      * @param string             $updated_by      Last changes was made by
-     * @param DateTimeImmutable           $active_from     Active from
-     * @param DateTimeImmutable           $active_to       Active to
+     * @param DateTimeImmutable  $active_from     Active from
+     * @param DateTimeImmutable  $active_to       Active to
      * @param int                $progress_ok     Successfully completed sources count
      * @param int                $progress_wait   Sources in a progress count
      * @param int                $progress_error  Errored sources count

--- a/src/Responses/Entities/ReportMade.php
+++ b/src/Responses/Entities/ReportMade.php
@@ -32,10 +32,10 @@ class ReportMade implements CanCreateSelfFromArrayInterface
     /**
      * Create a new report made instance.
      *
-     * @param string      $report_uid          Report unique ID
-     * @param bool        $is_new              Report is new?
-     * @param string|null $process_request_uid Unique report request ID
-     * @param DateTimeImmutable    $suggest_get         Suggested date/time for report getting
+     * @param string            $report_uid          Report unique ID
+     * @param bool              $is_new              Report is new?
+     * @param string|null       $process_request_uid Unique report request ID
+     * @param DateTimeImmutable $suggest_get         Suggested date/time for report getting
      */
     public function __construct(string $report_uid, bool $is_new, ?string $process_request_uid, DateTimeImmutable $suggest_get)
     {

--- a/src/Responses/Entities/ReportMade.php
+++ b/src/Responses/Entities/ReportMade.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 
 class ReportMade implements CanCreateSelfFromArrayInterface
@@ -25,7 +25,7 @@ class ReportMade implements CanCreateSelfFromArrayInterface
     protected $process_request_uid;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $suggest_get;
 
@@ -35,9 +35,9 @@ class ReportMade implements CanCreateSelfFromArrayInterface
      * @param string      $report_uid          Report unique ID
      * @param bool        $is_new              Report is new?
      * @param string|null $process_request_uid Unique report request ID
-     * @param DateTime    $suggest_get         Suggested date/time for report getting
+     * @param DateTimeImmutable    $suggest_get         Suggested date/time for report getting
      */
-    public function __construct(string $report_uid, bool $is_new, ?string $process_request_uid, DateTime $suggest_get)
+    public function __construct(string $report_uid, bool $is_new, ?string $process_request_uid, DateTimeImmutable $suggest_get)
     {
         $this->report_uid          = $report_uid;
         $this->is_new              = $is_new;
@@ -54,7 +54,7 @@ class ReportMade implements CanCreateSelfFromArrayInterface
             $data['uid'],
             $data['isnew'],
             $data['process_request_uid'] ?? null,
-            DateTimeFactory::createFromIso8601Zulu((string) $data['suggest_get'])
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu((string) $data['suggest_get']))
         );
     }
 
@@ -91,9 +91,9 @@ class ReportMade implements CanCreateSelfFromArrayInterface
     /**
      * Get suggested date/time for report getting.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getSuggestGet(): DateTime
+    public function getSuggestGet(): DateTimeImmutable
     {
         return $this->suggest_get;
     }

--- a/src/Responses/Entities/ReportType.php
+++ b/src/Responses/Entities/ReportType.php
@@ -183,12 +183,12 @@ class ReportType implements CanCreateSelfFromArrayInterface
      * @param int                    $period_priority  Time unit (in milliseconds) for priority calculation
      * @param int                    $max_request      Number of requests in a given time unit, which will lower the
      *                                                 priority to a minimum
-     * @param DateTimeImmutable               $created_at       Report type created at
+     * @param DateTimeImmutable      $created_at       Report type created at
      * @param string                 $created_by       Report type creator
-     * @param DateTimeImmutable               $updated_at       Last changes was made at
+     * @param DateTimeImmutable      $updated_at       Last changes was made at
      * @param string                 $updated_by       Last changes was made by
-     * @param DateTimeImmutable               $active_from      Active from
-     * @param DateTimeImmutable               $active_to        Active to
+     * @param DateTimeImmutable      $active_from      Active from
+     * @param DateTimeImmutable      $active_to        Active to
      * @param CleanOptions|null      $clean_options    Objects obsolescence
      * @param string|null            $report_make_mode Report generation mode (e.g.: `TRANSACTIONAL`,
      *                                                 `FAST_NON_TRANSACTIONAL`, `FAST_NON_BALANCE`)

--- a/src/Responses/Entities/ReportType.php
+++ b/src/Responses/Entities/ReportType.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 
 class ReportType implements CanCreateSelfFromArrayInterface
@@ -115,7 +115,7 @@ class ReportType implements CanCreateSelfFromArrayInterface
     protected $max_request;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $created_at;
 
@@ -125,7 +125,7 @@ class ReportType implements CanCreateSelfFromArrayInterface
     protected $created_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $updated_at;
 
@@ -135,12 +135,12 @@ class ReportType implements CanCreateSelfFromArrayInterface
     protected $updated_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_from;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_to;
 
@@ -183,12 +183,12 @@ class ReportType implements CanCreateSelfFromArrayInterface
      * @param int                    $period_priority  Time unit (in milliseconds) for priority calculation
      * @param int                    $max_request      Number of requests in a given time unit, which will lower the
      *                                                 priority to a minimum
-     * @param DateTime               $created_at       Report type created at
+     * @param DateTimeImmutable               $created_at       Report type created at
      * @param string                 $created_by       Report type creator
-     * @param DateTime               $updated_at       Last changes was made at
+     * @param DateTimeImmutable               $updated_at       Last changes was made at
      * @param string                 $updated_by       Last changes was made by
-     * @param DateTime               $active_from      Active from
-     * @param DateTime               $active_to        Active to
+     * @param DateTimeImmutable               $active_from      Active from
+     * @param DateTimeImmutable               $active_to        Active to
      * @param CleanOptions|null      $clean_options    Objects obsolescence
      * @param string|null            $report_make_mode Report generation mode (e.g.: `TRANSACTIONAL`,
      *                                                 `FAST_NON_TRANSACTIONAL`, `FAST_NON_BALANCE`)
@@ -210,12 +210,12 @@ class ReportType implements CanCreateSelfFromArrayInterface
                                 int $max_priority,
                                 int $period_priority,
                                 int $max_request,
-                                DateTime $created_at,
+                                DateTimeImmutable $created_at,
                                 string $created_by,
-                                DateTime $updated_at,
+                                DateTimeImmutable $updated_at,
                                 string $updated_by,
-                                DateTime $active_from,
-                                DateTime $active_to,
+                                DateTimeImmutable $active_from,
+                                DateTimeImmutable $active_to,
                                 ?CleanOptions $clean_options,
                                 ?string $report_make_mode,
                                 ?int $id,
@@ -271,12 +271,12 @@ class ReportType implements CanCreateSelfFromArrayInterface
             $data['max_priority'],
             $data['period_priority'],
             $data['max_request'],
-            DateTimeFactory::createFromIso8601Zulu($data['created_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['created_at'])),
             $data['created_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['updated_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['updated_at'])),
             $data['updated_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['active_from']),
-            DateTimeFactory::createFromIso8601Zulu($data['active_to']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_from'])),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_to'])),
             isset($data['clean_options'])
                 ? CleanOptions::fromArray($data['clean_options'])
                 : null,
@@ -439,9 +439,9 @@ class ReportType implements CanCreateSelfFromArrayInterface
     /**
      * Get created at date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->created_at;
     }
@@ -459,9 +459,9 @@ class ReportType implements CanCreateSelfFromArrayInterface
     /**
      * Get last changes date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updated_at;
     }
@@ -479,9 +479,9 @@ class ReportType implements CanCreateSelfFromArrayInterface
     /**
      * Get active from date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveFrom(): DateTime
+    public function getActiveFrom(): DateTimeImmutable
     {
         return $this->active_from;
     }
@@ -489,9 +489,9 @@ class ReportType implements CanCreateSelfFromArrayInterface
     /**
      * Get active to date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveTo(): DateTime
+    public function getActiveTo(): DateTimeImmutable
     {
         return $this->active_to;
     }

--- a/src/Responses/Entities/User.php
+++ b/src/Responses/Entities/User.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses\Entities;
 
-use DateTime;
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 
 class User implements CanCreateSelfFromArrayInterface
@@ -80,7 +80,7 @@ class User implements CanCreateSelfFromArrayInterface
     protected $tags;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $created_at;
 
@@ -90,7 +90,7 @@ class User implements CanCreateSelfFromArrayInterface
     protected $created_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $updated_at;
 
@@ -100,12 +100,12 @@ class User implements CanCreateSelfFromArrayInterface
     protected $updated_by;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_from;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $active_to;
 
@@ -138,12 +138,12 @@ class User implements CanCreateSelfFromArrayInterface
      * @param Domain|null   $domain      User domain object (optional)
      * @param array<string> $roles       User roles
      * @param array<string> $tags        Additional user tags
-     * @param DateTime      $created_at  User created at
+     * @param DateTimeImmutable      $created_at  User created at
      * @param string        $created_by  User creator
-     * @param DateTime      $updated_at  Last changes was made at
+     * @param DateTimeImmutable      $updated_at  Last changes was made at
      * @param string        $updated_by  Last changes was made by
-     * @param DateTime      $active_from Active from
-     * @param DateTime      $active_to   Active to
+     * @param DateTimeImmutable      $active_from Active from
+     * @param DateTimeImmutable      $active_to   Active to
      * @param int|null      $id          Internal database identifier (optional, only for administrators)
      * @param bool|null     $deleted     Is deleted flag (optional, only for administrators)
      * @param string|null   $pass_hash   Password hash (optional, only for administrators)
@@ -159,12 +159,12 @@ class User implements CanCreateSelfFromArrayInterface
                                 ?Domain $domain,
                                 array $roles,
                                 array $tags,
-                                DateTime $created_at,
+                                DateTimeImmutable $created_at,
                                 string $created_by,
-                                DateTime $updated_at,
+                                DateTimeImmutable $updated_at,
                                 string $updated_by,
-                                DateTime $active_from,
-                                DateTime $active_to,
+                                DateTimeImmutable $active_from,
+                                DateTimeImmutable $active_to,
                                 ?int $id,
                                 ?bool $deleted,
                                 ?string $pass_hash)
@@ -210,12 +210,12 @@ class User implements CanCreateSelfFromArrayInterface
                 : null,
             \array_filter(\explode(',', $data['roles'])),
             \array_filter(\explode(',', $data['tags'])),
-            DateTimeFactory::createFromIso8601Zulu($data['created_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['created_at'])),
             $data['created_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['updated_at']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['updated_at'])),
             $data['updated_by'],
-            DateTimeFactory::createFromIso8601Zulu($data['active_from']),
-            DateTimeFactory::createFromIso8601Zulu($data['active_to']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_from'])),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($data['active_to'])),
             $data['id'] ?? null,
             $data['deleted'] ?? null,
             $data['pass_hash'] ?? null
@@ -335,9 +335,9 @@ class User implements CanCreateSelfFromArrayInterface
     /**
      * Get created at date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->created_at;
     }
@@ -355,9 +355,9 @@ class User implements CanCreateSelfFromArrayInterface
     /**
      * Get last changes date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updated_at;
     }
@@ -375,9 +375,9 @@ class User implements CanCreateSelfFromArrayInterface
     /**
      * Get active from date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveFrom(): DateTime
+    public function getActiveFrom(): DateTimeImmutable
     {
         return $this->active_from;
     }
@@ -385,9 +385,9 @@ class User implements CanCreateSelfFromArrayInterface
     /**
      * Get active to date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getActiveTo(): DateTime
+    public function getActiveTo(): DateTimeImmutable
     {
         return $this->active_to;
     }

--- a/src/Responses/Entities/User.php
+++ b/src/Responses/Entities/User.php
@@ -127,26 +127,26 @@ class User implements CanCreateSelfFromArrayInterface
     /**
      * Create a new user instance.
      *
-     * @param string        $uid         Unique user ID
-     * @param string        $comment     User comment
-     * @param string        $contacts    User contact info
-     * @param string        $email       User email
-     * @param string        $login       Login (e.g. `user@domain`)
-     * @param string        $name        Human-readable user name
-     * @param string        $state       User status (e.g.: `ACTIVATION_REQUIRED`, `ACTIVE`, `BANNED`)
-     * @param string        $domain_uid  User domain unique ID
-     * @param Domain|null   $domain      User domain object (optional)
-     * @param array<string> $roles       User roles
-     * @param array<string> $tags        Additional user tags
-     * @param DateTimeImmutable      $created_at  User created at
-     * @param string        $created_by  User creator
-     * @param DateTimeImmutable      $updated_at  Last changes was made at
-     * @param string        $updated_by  Last changes was made by
-     * @param DateTimeImmutable      $active_from Active from
-     * @param DateTimeImmutable      $active_to   Active to
-     * @param int|null      $id          Internal database identifier (optional, only for administrators)
-     * @param bool|null     $deleted     Is deleted flag (optional, only for administrators)
-     * @param string|null   $pass_hash   Password hash (optional, only for administrators)
+     * @param string            $uid         Unique user ID
+     * @param string            $comment     User comment
+     * @param string            $contacts    User contact info
+     * @param string            $email       User email
+     * @param string            $login       Login (e.g. `user@domain`)
+     * @param string            $name        Human-readable user name
+     * @param string            $state       User status (e.g.: `ACTIVATION_REQUIRED`, `ACTIVE`, `BANNED`)
+     * @param string            $domain_uid  User domain unique ID
+     * @param Domain|null       $domain      User domain object (optional)
+     * @param array<string>     $roles       User roles
+     * @param array<string>     $tags        Additional user tags
+     * @param DateTimeImmutable $created_at  User created at
+     * @param string            $created_by  User creator
+     * @param DateTimeImmutable $updated_at  Last changes was made at
+     * @param string            $updated_by  Last changes was made by
+     * @param DateTimeImmutable $active_from Active from
+     * @param DateTimeImmutable $active_to   Active to
+     * @param int|null          $id          Internal database identifier (optional, only for administrators)
+     * @param bool|null         $deleted     Is deleted flag (optional, only for administrators)
+     * @param string|null       $pass_hash   Password hash (optional, only for administrators)
      */
     public function __construct(string $uid,
                                 string $comment,

--- a/src/Responses/UserBalanceResponse.php
+++ b/src/Responses/UserBalanceResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;

--- a/src/Responses/UserBalanceResponse.php
+++ b/src/Responses/UserBalanceResponse.php
@@ -92,7 +92,7 @@ class UserBalanceResponse implements ResponseInterface, Countable, IteratorAggre
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data']
         );
     }

--- a/src/Responses/UserBalanceResponse.php
+++ b/src/Responses/UserBalanceResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserBalanceResponse implements ResponseInterface, Countable, IteratorAggre
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -51,10 +51,10 @@ class UserBalanceResponse implements ResponseInterface, Countable, IteratorAggre
      * @param string              $raw_response
      * @param string              $state
      * @param int                 $size
-     * @param DateTime            $stamp
+     * @param DateTimeImmutable   $stamp
      * @param array<int, Balance> $data
      */
-    private function __construct(string $raw_response, string $state, int $size, DateTime $stamp, array $data)
+    private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)
     {
         $this->raw_response_content = $raw_response;
         $this->state                = $state;
@@ -92,7 +92,7 @@ class UserBalanceResponse implements ResponseInterface, Countable, IteratorAggre
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data']
         );
     }
@@ -120,9 +120,9 @@ class UserBalanceResponse implements ResponseInterface, Countable, IteratorAggre
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserReportMakeResponse.php
+++ b/src/Responses/UserReportMakeResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -51,10 +51,10 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
      * @param string                 $raw_response
      * @param string                 $state
      * @param int                    $size
-     * @param DateTime               $stamp
+     * @param DateTimeImmutable               $stamp
      * @param array<int, ReportMade> $data
      */
-    private function __construct(string $raw_response, string $state, int $size, DateTime $stamp, array $data)
+    private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)
     {
         $this->raw_response_content = $raw_response;
         $this->state                = $state;
@@ -92,7 +92,7 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data']
         );
     }
@@ -120,9 +120,9 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserReportMakeResponse.php
+++ b/src/Responses/UserReportMakeResponse.php
@@ -92,7 +92,7 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data']
         );
     }

--- a/src/Responses/UserReportMakeResponse.php
+++ b/src/Responses/UserReportMakeResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;
@@ -51,7 +51,7 @@ class UserReportMakeResponse implements ResponseInterface, Countable, IteratorAg
      * @param string                 $raw_response
      * @param string                 $state
      * @param int                    $size
-     * @param DateTimeImmutable               $stamp
+     * @param DateTimeImmutable      $stamp
      * @param array<int, ReportMade> $data
      */
     private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)

--- a/src/Responses/UserReportRefreshResponse.php
+++ b/src/Responses/UserReportRefreshResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;

--- a/src/Responses/UserReportRefreshResponse.php
+++ b/src/Responses/UserReportRefreshResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserReportRefreshResponse implements ResponseInterface, Countable, Iterato
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -51,10 +51,10 @@ class UserReportRefreshResponse implements ResponseInterface, Countable, Iterato
      * @param string                 $raw_response
      * @param string                 $state
      * @param int                    $size
-     * @param DateTime               $stamp
+     * @param DateTimeImmutable      $stamp
      * @param array<int, ReportMade> $data
      */
-    private function __construct(string $raw_response, string $state, int $size, DateTime $stamp, array $data)
+    private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)
     {
         $this->raw_response_content = $raw_response;
         $this->state                = $state;
@@ -92,7 +92,7 @@ class UserReportRefreshResponse implements ResponseInterface, Countable, Iterato
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data']
         );
     }
@@ -120,9 +120,9 @@ class UserReportRefreshResponse implements ResponseInterface, Countable, Iterato
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserReportRefreshResponse.php
+++ b/src/Responses/UserReportRefreshResponse.php
@@ -92,7 +92,7 @@ class UserReportRefreshResponse implements ResponseInterface, Countable, Iterato
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data']
         );
     }

--- a/src/Responses/UserReportResponse.php
+++ b/src/Responses/UserReportResponse.php
@@ -92,7 +92,7 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data']
         );
     }

--- a/src/Responses/UserReportResponse.php
+++ b/src/Responses/UserReportResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -51,10 +51,10 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
      * @param string             $raw_response
      * @param string             $state
      * @param int                $size
-     * @param DateTime           $stamp
+     * @param DateTimeImmutable           $stamp
      * @param array<int, Report> $data
      */
-    private function __construct(string $raw_response, string $state, int $size, DateTime $stamp, array $data)
+    private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)
     {
         $this->raw_response_content = $raw_response;
         $this->state                = $state;
@@ -92,7 +92,7 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data']
         );
     }
@@ -120,9 +120,9 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserReportResponse.php
+++ b/src/Responses/UserReportResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;
@@ -51,7 +51,7 @@ class UserReportResponse implements ResponseInterface, Countable, IteratorAggreg
      * @param string             $raw_response
      * @param string             $state
      * @param int                $size
-     * @param DateTimeImmutable           $stamp
+     * @param DateTimeImmutable  $stamp
      * @param array<int, Report> $data
      */
     private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)

--- a/src/Responses/UserReportTypesResponse.php
+++ b/src/Responses/UserReportTypesResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -56,14 +56,14 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
      * @param string                 $raw_response
      * @param string                 $state
      * @param int                    $size
-     * @param DateTime               $stamp
+     * @param DateTimeImmutable               $stamp
      * @param array<int, ReportType> $data
      * @param int|null               $total
      */
     private function __construct(string $raw_response,
                                  string $state,
                                  int $size,
-                                 DateTime $stamp,
+                                 DateTimeImmutable $stamp,
                                  array $data,
                                  ?int $total)
     {
@@ -104,7 +104,7 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data'],
             $as_array['total'] ?? null
         );
@@ -133,9 +133,9 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserReportTypesResponse.php
+++ b/src/Responses/UserReportTypesResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;
@@ -56,7 +56,7 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
      * @param string                 $raw_response
      * @param string                 $state
      * @param int                    $size
-     * @param DateTimeImmutable               $stamp
+     * @param DateTimeImmutable      $stamp
      * @param array<int, ReportType> $data
      * @param int|null               $total
      */

--- a/src/Responses/UserReportTypesResponse.php
+++ b/src/Responses/UserReportTypesResponse.php
@@ -104,7 +104,7 @@ class UserReportTypesResponse implements ResponseInterface, Countable, IteratorA
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data'],
             $as_array['total'] ?? null
         );

--- a/src/Responses/UserReportsResponse.php
+++ b/src/Responses/UserReportsResponse.php
@@ -104,7 +104,7 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data'],
             $as_array['total'] ?? null
         );

--- a/src/Responses/UserReportsResponse.php
+++ b/src/Responses/UserReportsResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;
@@ -56,7 +56,7 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
      * @param string             $raw_response
      * @param string             $state
      * @param int                $size
-     * @param DateTimeImmutable           $stamp
+     * @param DateTimeImmutable  $stamp
      * @param array<int, Report> $data
      * @param int|null           $total
      */

--- a/src/Responses/UserReportsResponse.php
+++ b/src/Responses/UserReportsResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -56,14 +56,14 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
      * @param string             $raw_response
      * @param string             $state
      * @param int                $size
-     * @param DateTime           $stamp
+     * @param DateTimeImmutable           $stamp
      * @param array<int, Report> $data
      * @param int|null           $total
      */
     private function __construct(string $raw_response,
                                  string $state,
                                  int $size,
-                                 DateTime $stamp,
+                                 DateTimeImmutable $stamp,
                                  array $data,
                                  ?int $total)
     {
@@ -104,7 +104,7 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data'],
             $as_array['total'] ?? null
         );
@@ -133,9 +133,9 @@ class UserReportsResponse implements ResponseInterface, Countable, IteratorAggre
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserResponse.php
+++ b/src/Responses/UserResponse.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTime;
+use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
@@ -36,7 +36,7 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
     protected $size;
 
     /**
-     * @var DateTime
+     * @var DateTimeImmutable
      */
     protected $stamp;
 
@@ -51,10 +51,10 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
      * @param string           $raw_response
      * @param string           $state
      * @param int              $size
-     * @param DateTime         $stamp
+     * @param DateTimeImmutable         $stamp
      * @param array<int, User> $data
      */
-    private function __construct(string $raw_response, string $state, int $size, DateTime $stamp, array $data)
+    private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)
     {
         $this->raw_response_content = $raw_response;
         $this->state                = $state;
@@ -92,7 +92,7 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createFromIso8601Zulu($as_array['stamp']),
+            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
             $as_array['data']
         );
     }
@@ -120,9 +120,9 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
     /**
      * Get response date/time.
      *
-     * @return DateTime
+     * @return DateTimeImmutable
      */
-    public function getStamp(): DateTime
+    public function getStamp(): DateTimeImmutable
     {
         return $this->stamp;
     }

--- a/src/Responses/UserResponse.php
+++ b/src/Responses/UserResponse.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Responses;
 
-use DateTimeImmutable;
 use Countable;
 use ArrayIterator;
+use DateTimeImmutable;
 use IteratorAggregate;
 use Tarampampam\Wrappers\Json;
 use Avtocod\B2BApi\DateTimeFactory;
@@ -48,11 +48,11 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
     /**
      * Create a new response instance.
      *
-     * @param string           $raw_response
-     * @param string           $state
-     * @param int              $size
-     * @param DateTimeImmutable         $stamp
-     * @param array<int, User> $data
+     * @param string            $raw_response
+     * @param string            $state
+     * @param int               $size
+     * @param DateTimeImmutable $stamp
+     * @param array<int, User>  $data
      */
     private function __construct(string $raw_response, string $state, int $size, DateTimeImmutable $stamp, array $data)
     {

--- a/src/Responses/UserResponse.php
+++ b/src/Responses/UserResponse.php
@@ -92,7 +92,7 @@ class UserResponse implements WithRawResponseGetterInterface, ResponseInterface,
             $raw_response,
             $as_array['state'],
             $as_array['size'],
-            DateTimeFactory::createImmutableFromIso8601Zulu($as_array['stamp']),
+            DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($as_array['stamp'])),
             $as_array['data']
         );
     }

--- a/tests/Unit/Responses/Entities/BalanceTest.php
+++ b/tests/Unit/Responses/Entities/BalanceTest.php
@@ -7,6 +7,7 @@ namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Balance;
+use DateTimeImmutable;
 
 /**
  * @group  entities
@@ -29,8 +30,8 @@ class BalanceTest extends AbstractTestCase
             $quote_init = $attributes['quote_init'],
             $quote_up = $attributes['quote_up'],
             $quote_use = $attributes['quote_use'],
-            $created_at = DateTimeFactory::createFromIso8601Zulu($attributes['created_at']),
-            $updated_at = DateTimeFactory::createFromIso8601Zulu($attributes['updated_at'])
+            $created_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['created_at'])),
+            $updated_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['updated_at']))
         );
 
         $this->assertSame($report_type_uid, $balance->getReportTypeUid());

--- a/tests/Unit/Responses/Entities/BalanceTest.php
+++ b/tests/Unit/Responses/Entities/BalanceTest.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Balance;
-use DateTimeImmutable;
 
 /**
  * @group  entities

--- a/tests/Unit/Responses/Entities/DomainTest.php
+++ b/tests/Unit/Responses/Entities/DomainTest.php
@@ -7,6 +7,7 @@ namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Domain;
+use DateTimeImmutable;
 
 /**
  * @group  entities
@@ -30,12 +31,12 @@ class DomainTest extends AbstractTestCase
             $state = $attributes['state'],
             $roles = \explode(',', $attributes['roles']),
             $tags = \explode(',', $attributes['tags']),
-            $created_at = DateTimeFactory::createFromIso8601Zulu($attributes['created_at']),
+            $created_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['created_at'])),
             $created_by = $attributes['created_by'],
-            $updated_at = DateTimeFactory::createFromIso8601Zulu($attributes['updated_at']),
+            $updated_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['updated_at'])),
             $updated_by = $attributes['updated_by'],
-            $active_from = DateTimeFactory::createFromIso8601Zulu($attributes['active_from']),
-            $active_to = DateTimeFactory::createFromIso8601Zulu($attributes['active_to']),
+            $active_from = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_from'])),
+            $active_to = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_to'])),
             $id = $attributes['id'],
             $deleted = $attributes['deleted']
         );

--- a/tests/Unit/Responses/Entities/DomainTest.php
+++ b/tests/Unit/Responses/Entities/DomainTest.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Domain;
-use DateTimeImmutable;
 
 /**
  * @group  entities

--- a/tests/Unit/Responses/Entities/EntitiesFactory.php
+++ b/tests/Unit/Responses/Entities/EntitiesFactory.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Faker\Generator as Faker;
 use InvalidArgumentException;
 use Avtocod\B2BApi\DateTimeFactory;
@@ -83,18 +84,18 @@ class EntitiesFactory
                     : $faker->randomElement([[], ['site', 'robot']]),
                 'created_at'  => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisYear)
-                    : $faker->dateTimeThisYear,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisYear),
                 'created_by'  => $faker->userName,
                 'updated_at'  => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisMonth)
-                    : $faker->dateTimeThisMonth,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisMonth),
                 'updated_by'  => $faker->userName,
                 'active_from' => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisMonth)
-                    : $faker->dateTimeThisMonth,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisMonth),
                 'active_to'   => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisMonth)
-                    : $faker->dateTimeThisMonth,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisMonth),
                 'id'          => $faker->randomElement([null, $faker->randomNumber()]),
                 'deleted'     => $faker->randomElement([null, $faker->boolean]),
             ], $attributes);
@@ -298,18 +299,18 @@ class EntitiesFactory
                     : $faker->randomElement([[], [$faker->word, $faker->word]]),
                 'created_at'      => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisYear)
-                    : $faker->dateTimeThisYear,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisYear),
                 'created_by'      => $faker->userName,
                 'updated_at'      => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisMonth)
-                    : $faker->dateTimeThisMonth,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisMonth),
                 'updated_by'      => $faker->userName,
                 'active_from'     => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisMonth)
-                    : $faker->dateTimeThisMonth,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisMonth),
                 'active_to'       => $as_array
                     ? DateTimeFactory::toIso8601Zulu($faker->dateTimeThisMonth)
-                    : $faker->dateTimeThisMonth,
+                    : DateTimeImmutable::createFromMutable($faker->dateTimeThisMonth),
                 'progress_ok'     => $faker->numberBetween(0, 15),
                 'progress_wait'   => $faker->numberBetween(0, 15),
                 'progress_error'  => $faker->numberBetween(0, 15),

--- a/tests/Unit/Responses/Entities/GroupTest.php
+++ b/tests/Unit/Responses/Entities/GroupTest.php
@@ -7,6 +7,7 @@ namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Group;
+use DateTimeImmutable;
 
 /**
  * @group  entities
@@ -30,12 +31,12 @@ class GroupTest extends AbstractTestCase
             $users = $attributes['users'],
             $roles = \explode(',', $attributes['roles']),
             $tags = \explode(',', $attributes['tags']),
-            $created_at = DateTimeFactory::createFromIso8601Zulu($attributes['created_at']),
+            $created_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['created_at'])),
             $created_by = $attributes['created_by'],
-            $updated_at = DateTimeFactory::createFromIso8601Zulu($attributes['updated_at']),
+            $updated_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['updated_at'])),
             $updated_by = $attributes['updated_by'],
-            $active_from = DateTimeFactory::createFromIso8601Zulu($attributes['active_from']),
-            $active_to = DateTimeFactory::createFromIso8601Zulu($attributes['active_to']),
+            $active_from = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_from'])),
+            $active_to = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_to'])),
             $id = $attributes['id'],
             $deleted = $attributes['deleted']
         );

--- a/tests/Unit/Responses/Entities/GroupTest.php
+++ b/tests/Unit/Responses/Entities/GroupTest.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Group;
-use DateTimeImmutable;
 
 /**
  * @group  entities

--- a/tests/Unit/Responses/Entities/ReportMadeTest.php
+++ b/tests/Unit/Responses/Entities/ReportMadeTest.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\ReportMade;
-use DateTimeImmutable;
 
 /**
  * @covers \Avtocod\B2BApi\Responses\Entities\ReportMade

--- a/tests/Unit/Responses/Entities/ReportMadeTest.php
+++ b/tests/Unit/Responses/Entities/ReportMadeTest.php
@@ -7,6 +7,7 @@ namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\ReportMade;
+use DateTimeImmutable;
 
 /**
  * @covers \Avtocod\B2BApi\Responses\Entities\ReportMade
@@ -25,7 +26,7 @@ class ReportMadeTest extends AbstractTestCase
             $report_uid = $attributes['report_uid'],
             $is_new = $attributes['is_new'],
             $process_request_uid = $attributes['process_request_uid'],
-            $suggest_get = DateTimeFactory::createFromIso8601Zulu($attributes['suggest_get'])
+            $suggest_get = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['suggest_get']))
         );
 
         $this->assertSame($report_uid, $made->getReportUid());

--- a/tests/Unit/Responses/Entities/ReportTest.php
+++ b/tests/Unit/Responses/Entities/ReportTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\Report;
 use Avtocod\B2BApi\Responses\Entities\ReportQuery;
 use Avtocod\B2BApi\Responses\Entities\ReportState;
 use Avtocod\B2BApi\Responses\Entities\ReportContent;
-use DateTimeImmutable;
 
 /**
  * @group  entities

--- a/tests/Unit/Responses/Entities/ReportTest.php
+++ b/tests/Unit/Responses/Entities/ReportTest.php
@@ -10,6 +10,7 @@ use Avtocod\B2BApi\Responses\Entities\Report;
 use Avtocod\B2BApi\Responses\Entities\ReportQuery;
 use Avtocod\B2BApi\Responses\Entities\ReportState;
 use Avtocod\B2BApi\Responses\Entities\ReportContent;
+use DateTimeImmutable;
 
 /**
  * @group  entities
@@ -36,12 +37,12 @@ class ReportTest extends AbstractTestCase
             $report_type_uid = $attributes['report_type_uid'],
             $domain_uid = $attributes['domain_uid'],
             $tags = \explode(',', $attributes['tags']),
-            $created_at = DateTimeFactory::createFromIso8601Zulu($attributes['created_at']),
+            $created_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['created_at'])),
             $created_by = $attributes['created_by'],
-            $updated_at = DateTimeFactory::createFromIso8601Zulu($attributes['updated_at']),
+            $updated_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['updated_at'])),
             $updated_by = $attributes['updated_by'],
-            $active_from = DateTimeFactory::createFromIso8601Zulu($attributes['active_from']),
-            $active_to = DateTimeFactory::createFromIso8601Zulu($attributes['active_to']),
+            $active_from = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_from'])),
+            $active_to = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_to'])),
             $progress_ok = $attributes['progress_ok'],
             $progress_wait = $attributes['progress_wait'],
             $progress_error = $attributes['progress_error'],

--- a/tests/Unit/Responses/Entities/ReportTypeTest.php
+++ b/tests/Unit/Responses/Entities/ReportTypeTest.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\ReportType;
 use Avtocod\B2BApi\Responses\Entities\CleanOptions;
 use Avtocod\B2BApi\Responses\Entities\ReportTypeContent;
-use DateTimeImmutable;
 
 /**
  * @covers \Avtocod\B2BApi\Responses\Entities\ReportType

--- a/tests/Unit/Responses/Entities/ReportTypeTest.php
+++ b/tests/Unit/Responses/Entities/ReportTypeTest.php
@@ -9,6 +9,7 @@ use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\ReportType;
 use Avtocod\B2BApi\Responses\Entities\CleanOptions;
 use Avtocod\B2BApi\Responses\Entities\ReportTypeContent;
+use DateTimeImmutable;
 
 /**
  * @covers \Avtocod\B2BApi\Responses\Entities\ReportType
@@ -52,12 +53,12 @@ class ReportTypeTest extends AbstractTestCase
             $max_priority = $attributes['max_priority'],
             $period_priority = $attributes['period_priority'],
             $max_request = $attributes['max_request'],
-            $created_at = DateTimeFactory::createFromIso8601Zulu($attributes['created_at']),
+            $created_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['created_at'])),
             $created_by = $attributes['created_by'],
-            $updated_at = DateTimeFactory::createFromIso8601Zulu($attributes['updated_at']),
+            $updated_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['updated_at'])),
             $updated_by = $attributes['updated_by'],
-            $active_from = DateTimeFactory::createFromIso8601Zulu($attributes['active_from']),
-            $active_to = DateTimeFactory::createFromIso8601Zulu($attributes['active_to']),
+            $active_from = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_from'])),
+            $active_to = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_to'])),
             $clean_options = EntitiesFactory::make(CleanOptions::class),
             $report_make_mode = $attributes['report_make_mode'],
             $id = $attributes['id'],

--- a/tests/Unit/Responses/Entities/UserTest.php
+++ b/tests/Unit/Responses/Entities/UserTest.php
@@ -8,6 +8,7 @@ use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\User;
 use Avtocod\B2BApi\Responses\Entities\Domain;
+use DateTimeImmutable;
 
 /**
  * @group  entities
@@ -46,12 +47,12 @@ class UserTest extends AbstractTestCase
             $domain = $this->faker->randomElement([null, EntitiesFactory::make(Domain::class)]),
             $roles = \explode(',', $attributes['roles']),
             $tags = \explode(',', $attributes['tags']),
-            $created_at = DateTimeFactory::createFromIso8601Zulu($attributes['created_at']),
+            $created_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['created_at'])),
             $created_by = $attributes['created_by'],
-            $updated_at = DateTimeFactory::createFromIso8601Zulu($attributes['updated_at']),
+            $updated_at = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['updated_at'])),
             $updated_by = $attributes['updated_by'],
-            $active_from = DateTimeFactory::createFromIso8601Zulu($attributes['active_from']),
-            $active_to = DateTimeFactory::createFromIso8601Zulu($attributes['active_to']),
+            $active_from = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_from'])),
+            $active_to = DateTimeImmutable::createFromMutable(DateTimeFactory::createFromIso8601Zulu($attributes['active_to'])),
             $id = $attributes['id'],
             $deleted = $attributes['deleted'],
             $pass_hash = $attributes['pass_hash']

--- a/tests/Unit/Responses/Entities/UserTest.php
+++ b/tests/Unit/Responses/Entities/UserTest.php
@@ -4,11 +4,11 @@ declare(strict_types = 1);
 
 namespace Avtocod\B2BApi\Tests\Unit\Responses\Entities;
 
+use DateTimeImmutable;
 use Avtocod\B2BApi\DateTimeFactory;
 use Avtocod\B2BApi\Tests\AbstractTestCase;
 use Avtocod\B2BApi\Responses\Entities\User;
 use Avtocod\B2BApi\Responses\Entities\Domain;
-use DateTimeImmutable;
 
 /**
  * @group  entities


### PR DESCRIPTION
## Description

- Date/time objects in service responses & entities not immutable (`DateTimeImmutable` instead `DateTime`)

Fixes #21 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
